### PR TITLE
Ease up core file generation

### DIFF
--- a/grading/cpp/Dockerfile
+++ b/grading/cpp/Dockerfile
@@ -5,3 +5,9 @@ FROM    ingi/inginious-c-default
 
 # Add gcc
 RUN     yum install -y gcc cpp make valgrind binutils libstdc++ clang llvm automake check check-devel CUnit CUnit-devel zlib-devel
+
+# We don't want the abrt daemon eating the coredumps
+RUN     yum remove -y abrt*
+
+# We want coredumps named 'core' in the current directory
+RUN     echo "kernel.core_pattern=core" >> /etc/sysctl.conf


### PR DESCRIPTION
Currently, the abrt daemon is 'eating' all coredumps, and by default dismissing the ones not coming installed rpm's.

Disabling it and restoring the default kernel behavior makes life easier for batch analysis.

@INGIniousBot ok to test