### PR TITLE
cpp: Add gdb

### DIFF
--- a/grading/cpp/Dockerfile
+++ b/grading/cpp/Dockerfile
@@ -4,4 +4,4 @@
 FROM    ingi/inginious-c-default
 
 # Add gcc
-RUN     yum install -y gcc cpp make valgrind binutils libstdc++ clang clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time
+RUN     yum install -y gcc gdb cpp make valgrind binutils libstdc++ clang clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time


### PR DESCRIPTION
Adding gdb would let us provide backtrace when student's code crashes through the coredump file.