### PR TITLE
base: Add file command

### DIFF
--- a/grading/base/Dockerfile
+++ b/grading/base/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_ALL en_US.UTF-8
 # Install python, needed for scripts used in INGInious
 RUN     yum clean metadata && \
         yum -y install https://centos7.iuscommunity.org/ius-release.rpm && \
-        yum -y install python python35u-pip python35u zip unzip tar sed openssh-server openssl bind-utils iproute && \
+        yum -y install python python35u-pip python35u zip unzip tar sed openssh-server openssl bind-utils iproute file && \
         pip3.5 install msgpack-python pyzmq && ln -s /usr/bin/python3.5 /usr/bin/python3 && \
         yum clean all
 


### PR DESCRIPTION
The base container lost the file command, which is *super* useful to understand what a student has uploaded (e.g., detect a tar file that has been renamed to *.zip to be uploaded ...)

Having it back would be appreciated!