### PR TITLE
Added GCC 5, 6, 7, and 8 images with and without OpenMPI environment

### DIFF
--- a/grading/gcc5-openmpi/Dockerfile
+++ b/grading/gcc5-openmpi/Dockerfile
@@ -1,0 +1,21 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc5-openmpi"
+
+# Install Developer Toolset 5
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-5-rpms && \
+        yum install -y openmpi openmpi-devel devtoolset-5-gcc devtoolset-5-gcc-c++ devtoolset-5-gdb devtoolset-5-cpp devtoolset-5-make cmake devtoolset-5-valgrind devtoolset-5-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-5 default compiler
+ENV	PATH=/opt/rh/devtoolset-5/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-5/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-5/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-5/root
+ENV	PERL5LIB=/opt/rh/devtoolset-5/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-5/root/usr/lib/perl5:/opt/rh/devtoolset-5/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-5/root/usr/lib64:/opt/rh/devtoolset-5/root/usr/lib:/opt/rh/devtoolset-5/root/usr/lib64/dyninst:/opt/rh/devtoolset-5/root/usr/lib/dyninst:/opt/rh/devtoolset-5/root/usr/lib64:/opt/rh/devtoolset-5/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-5/root/usr/lib64/python2.5/site-packages:/opt/rh/devtoolset-5/root/usr/lib/python2.5/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+ENV     PATH=/usr/lib64/openmpi/bin${PATH:+:${PATH}}

--- a/grading/gcc5-openmpi/README.md
+++ b/grading/gcc5-openmpi/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc5-openmpi (ingi/inginious-c-cpp-gcc5-openmpi)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 5) as main languages and OpenMPI environment

--- a/grading/gcc5/Dockerfile
+++ b/grading/gcc5/Dockerfile
@@ -1,0 +1,20 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc5"
+
+# Install Developer Toolset 5
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-5-rpms && \
+        yum install -y devtoolset-5-gcc devtoolset-5-gcc-c++ devtoolset-5-gdb devtoolset-5-cpp devtoolset-5-make cmake devtoolset-5-valgrind devtoolset-5-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-5 default compiler
+ENV	PATH=/opt/rh/devtoolset-5/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-5/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-5/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-5/root
+ENV	PERL5LIB=/opt/rh/devtoolset-5/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-5/root/usr/lib/perl5:/opt/rh/devtoolset-5/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-5/root/usr/lib64:/opt/rh/devtoolset-5/root/usr/lib:/opt/rh/devtoolset-5/root/usr/lib64/dyninst:/opt/rh/devtoolset-5/root/usr/lib/dyninst:/opt/rh/devtoolset-5/root/usr/lib64:/opt/rh/devtoolset-5/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-5/root/usr/lib64/python2.5/site-packages:/opt/rh/devtoolset-5/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}

--- a/grading/gcc5/README.md
+++ b/grading/gcc5/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc5 (ingi/inginious-c-cpp-gcc5)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 5) as main languages

--- a/grading/gcc6-openmpi/Dockerfile
+++ b/grading/gcc6-openmpi/Dockerfile
@@ -1,0 +1,21 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc6-openmpi"
+
+# Install Developer Toolset 6
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-6-rpms && \
+        yum install -y openmpi openmpi-devel devtoolset-6-gcc devtoolset-6-gcc-c++ devtoolset-6-gdb devtoolset-6-cpp devtoolset-6-make cmake devtoolset-6-valgrind devtoolset-6-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-6 default compiler
+ENV	PATH=/opt/rh/devtoolset-6/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-6/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-6/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-6/root
+ENV	PERL5LIB=/opt/rh/devtoolset-6/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-6/root/usr/lib/perl5:/opt/rh/devtoolset-6/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-6/root/usr/lib64/python2.6/site-packages:/opt/rh/devtoolset-6/root/usr/lib/python2.6/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+ENV     PATH=/usr/lib64/openmpi/bin${PATH:+:${PATH}}

--- a/grading/gcc6-openmpi/README.md
+++ b/grading/gcc6-openmpi/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc6-openmpi (ingi/inginious-c-cpp-gcc6-openmpi)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 6) as main languages and OpenMPI environment

--- a/grading/gcc6/Dockerfile
+++ b/grading/gcc6/Dockerfile
@@ -1,0 +1,20 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc6"
+
+# Install Developer Toolset 6
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-6-rpms && \
+        yum install -y devtoolset-6-gcc devtoolset-6-gcc-c++ devtoolset-6-gdb devtoolset-6-cpp devtoolset-6-make cmake devtoolset-6-valgrind devtoolset-6-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-6 default compiler
+ENV	PATH=/opt/rh/devtoolset-6/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-6/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-6/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-6/root
+ENV	PERL5LIB=/opt/rh/devtoolset-6/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-6/root/usr/lib/perl5:/opt/rh/devtoolset-6/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-6/root/usr/lib64/python2.6/site-packages:/opt/rh/devtoolset-6/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}

--- a/grading/gcc6/README.md
+++ b/grading/gcc6/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc6 (ingi/inginious-c-cpp-gcc6)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 6) as main languages

--- a/grading/gcc7-openmpi/Dockerfile
+++ b/grading/gcc7-openmpi/Dockerfile
@@ -1,0 +1,21 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc7-openmpi"
+
+# Install Developer Toolset 7
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+        yum install -y openmpi openmpi-devel devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gdb devtoolset-7-cpp devtoolset-7-make cmake devtoolset-7-valgrind devtoolset-7-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-7 default compiler
+ENV	PATH=/opt/rh/devtoolset-7/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-7/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-7/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-7/root
+ENV	PERL5LIB=/opt/rh/devtoolset-7/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-7/root/usr/lib/perl5:/opt/rh/devtoolset-7/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst:/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-7/root/usr/lib64/python2.7/site-packages:/opt/rh/devtoolset-7/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+ENV     PATH=/usr/lib64/openmpi/bin${PATH:+:${PATH}}

--- a/grading/gcc7-openmpi/README.md
+++ b/grading/gcc7-openmpi/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc7-openmpi (ingi/inginious-c-cpp-gcc7-openmpi)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 7) as main languages and OpenMPI environment

--- a/grading/gcc7/Dockerfile
+++ b/grading/gcc7/Dockerfile
@@ -1,0 +1,20 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc7"
+
+# Install Developer Toolset 7
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+        yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gdb devtoolset-7-cpp devtoolset-7-make cmake devtoolset-7-valgrind devtoolset-7-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-7 default compiler
+ENV	PATH=/opt/rh/devtoolset-7/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-7/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-7/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-7/root
+ENV	PERL5LIB=/opt/rh/devtoolset-7/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-7/root/usr/lib/perl5:/opt/rh/devtoolset-7/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib:/opt/rh/devtoolset-7/root/usr/lib64/dyninst:/opt/rh/devtoolset-7/root/usr/lib/dyninst:/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-7/root/usr/lib64/python2.7/site-packages:/opt/rh/devtoolset-7/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}

--- a/grading/gcc7/README.md
+++ b/grading/gcc7/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc7 (ingi/inginious-c-cpp-gcc7)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 7) as main languages

--- a/grading/gcc8-openmpi/Dockerfile
+++ b/grading/gcc8-openmpi/Dockerfile
@@ -1,0 +1,21 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc8-openmpi"
+
+# Install Developer Toolset 8
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-8-rpms && \
+        yum install -y openmpi openmpi-devel devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gdb devtoolset-8-cpp devtoolset-8-make cmake devtoolset-8-valgrind devtoolset-8-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-8 default compiler
+ENV	PATH=/opt/rh/devtoolset-8/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-8/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-8/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-8/root
+ENV	PERL5LIB=/opt/rh/devtoolset-8/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-8/root/usr/lib/perl5:/opt/rh/devtoolset-8/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-8/root/usr/lib64/python2.8/site-packages:/opt/rh/devtoolset-8/root/usr/lib/python2.8/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+ENV     PATH=/usr/lib64/openmpi/bin${PATH:+:${PATH}}

--- a/grading/gcc8-openmpi/README.md
+++ b/grading/gcc8-openmpi/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc8-openmpi (ingi/inginious-c-cpp-gcc8-openmpi)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 8) as main languages and OpenMPI environment

--- a/grading/gcc8/Dockerfile
+++ b/grading/gcc8/Dockerfile
@@ -1,0 +1,20 @@
+# DOCKER-VERSION 1.1.0
+
+# Inherit from the base container, which have all the needed script to launch tasks
+FROM    ingi/inginious-c-base
+LABEL   org.inginious.grading.name="cpp-gcc8"
+
+# Install Developer Toolset 8
+RUN     yum install -y centos-release-scl && \
+        yum-config-manager --enable rhel-server-rhscl-8-rpms && \
+        yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gdb devtoolset-8-cpp devtoolset-8-make cmake devtoolset-8-valgrind devtoolset-8-binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck && \
+        yum clean all    
+
+# Make GCC-8 default compiler
+ENV	PATH=/opt/rh/devtoolset-8/root/usr/bin${PATH:+:${PATH}}
+ENV	MANPATH=/opt/rh/devtoolset-8/root/usr/share/man:${MANPATH}
+ENV	INFOPATH=/opt/rh/devtoolset-8/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+ENV	PCP_DIR=/opt/rh/devtoolset-8/root
+ENV	PERL5LIB=/opt/rh/devtoolset-8/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-8/root/usr/lib/perl5:/opt/rh/devtoolset-8/root//usr/share/perl5/vendor_perl${PERL5LIB:+:${PERL5LIB}}
+ENV	LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV	PYTHONPATH=/opt/rh/devtoolset-8/root/usr/lib64/python2.8/site-packages:/opt/rh/devtoolset-8/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}

--- a/grading/gcc8/README.md
+++ b/grading/gcc8/README.md
@@ -1,0 +1,9 @@
+INGInious
+=========
+
+This container is part of [INGInious](https://github.com/UCL-INGI/INGInious), an intelligent grader that allows secured and automated testing of code made by students.
+
+Container cpp-gcc8 (ingi/inginious-c-cpp-gcc8)
+--------------------------------------------------------
+
+A container with C/C++ (GCC 8) as main languages


### PR DESCRIPTION
This PR adds container images for GCC 5, 6, 7, and 8 as main programming language with and without OpenMPI environment installed.