### PR TITLE
Adds python3 and python3-pip rpm packages to cpp container

### DIFF
--- a/grading/cpp/Dockerfile
+++ b/grading/cpp/Dockerfile
@@ -5,6 +5,6 @@ FROM    ingi/inginious-c-base
 LABEL org.inginious.grading.name="cpp"
 
 # Add gcc
-RUN     yum install -y gcc gcc-c++ gdb cpp make cmake valgrind binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck git && \
+RUN     yum install -y gcc gcc-c++ gdb cpp make cmake valgrind binutils libstdc++ clang clang-analyzer clang-devel llvm automake check check-devel CUnit CUnit-devel zlib-devel openssl-devel time jansson-devel graphviz graphviz-devel cppcheck git python3 python3-pip && \
         pip3 install GitPython && \
         yum clean all


### PR DESCRIPTION
Somehow the cpp container was failing to built and reporting that pip3 was missing. This issue may affect other containers but I haven't checked.