### PR TITLE
java: build powermock locally

### DIFF
--- a/grading/java/Dockerfile
+++ b/grading/java/Dockerfile
@@ -4,15 +4,10 @@ ARG   VERSION=latest
 FROM  ingi/inginious-c-base:${VERSION}
 LABEL org.inginious.grading.name="java"
 # Add mockito and depencies
-RUN     yum install -y  java-latest-openjdk java-latest-openjdk-devel ant ant-junit bc enca file && \
+RUN     yum install -y  java-latest-openjdk java-latest-openjdk-devel ant ant-junit bc enca file wget && \
         yum clean all && \
         alternatives --set java java-latest-openjdk.x86_64 && alternatives --set javac java-latest-openjdk.x86_64 && \
-        cd /usr/share/java && yum install -y wget && \
-        wget -O powermock.zip https://dl.bintray.com/powermock/generic/distributions/powermock-mockito2-junit-1.7.4.zip && \
-        unzip powermock.zip && \
-        cd powermock-mockito2-junit-1.7.4 && \
-        wget https://repo1.maven.org/maven2/org/powermock/powermock-api-mockito-common/1.7.4/powermock-api-mockito-common-1.7.4.jar && \
-        cd .. &&  rm powermock.zip && \
-        wget -O gradle.zip https://services.gradle.org/distributions/gradle-6.5.1-bin.zip && \
-        unzip -d /opt/ gradle.zip && ln -s /opt/gradle-6.5.1/bin/gradle /usr/local/bin/gradle && \
+        # Install gradle
+        wget -O gradle.zip https://services.gradle.org/distributions/gradle-7.0.1-bin.zip && \
+        unzip -d /opt/ gradle.zip && ln -s /opt/gradle-7.0.1/bin/gradle /usr/local/bin/gradle && \
         rm gradle.zip

--- a/grading/java8/Dockerfile
+++ b/grading/java8/Dockerfile
@@ -6,5 +6,14 @@ FROM  ingi/inginious-c-base:${VERSION}
 LABEL org.inginious.grading.name="java8"
 
 # Add java 1.8
-RUN     yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel ant ant-junit bc enca file && \
-        yum clean all
+RUN     yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel ant ant-junit bc enca file wget && \
+        yum clean all && \
+        # Build and install powermock
+        cd /tmp && \
+        wget https://github.com/powermock/powermock/archive/refs/tags/powermock-2.0.9.zip && \
+        unzip -d /tmp/ powermock-2.0.9.zip && \
+        cd /tmp/powermock-powermock-2.0.9 && \
+        JAVA_HOME=/usr/lib/jvm/java-1.8.0 ./gradlew distZip && \
+        unzip -d /usr/share/java /tmp/powermock-powermock-2.0.9/powermock-release/powermock-mockito2-junit/build/distributions/powermock-mockito2-junit-2.0.10.zip && \
+        rm -rf /tmp/powermock-powermock-2.0.9 && \
+        rm /tmp/powermock-2.0.9.zip


### PR DESCRIPTION
Moves powermock to java8 container as it seems it might not work with newer versions at all, see: https://github.com/powermock/powermock/issues/1083 or https://github.com/powermock/powermock/issues/1094

Update gradle in java-latest container.