### PR TITLE
[deeplearning-gpu] add container

### DIFF
--- a/grading/python3-deeplearning-gpu/.tf_configure.bazelrc
+++ b/grading/python3-deeplearning-gpu/.tf_configure.bazelrc
@@ -1,0 +1,9 @@
+build --action_env PYTHON_BIN_PATH="/usr/bin/python3"
+build --action_env PYTHON_LIB_PATH="/usr/lib/python3.8/site-packages"
+build --python_path="/usr/bin/python3"
+build --config=native_arch_linux
+build --config=tensorrt
+build --config=cuda
+build --action_env CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
+build --action_env TF_CUDA_COMPUTE_CAPABILITIES="5.0,7.5"
+build --action_env GCC_HOST_COMPILER_PATH="/opt/rh/gcc-toolset-11/root/usr/bin/gcc"

--- a/grading/python3-deeplearning-gpu/Dockerfile
+++ b/grading/python3-deeplearning-gpu/Dockerfile
@@ -10,8 +10,25 @@ LABEL org.inginious.grading.need_gpu=1
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
-# Install CUDA packages and compatible tensorflow version
-RUN dnf -y install dnf-plugins-core gcc-c++ python38-pip python38-devel && \
+ADD .tf_configure.bazelrc /tmp/
+
+# Install CUDA packages (latest and 11) and build tensorflow
+RUN dnf -y install gcc-toolset-11 dnf-plugins-core python38-pip python38-devel perl python2 unzip wget && \
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
-    dnf -y install cuda-toolkit-11-8 cuda-toolkit-12-0 tensorrt && \ 
-    pip3.8 install tensorflow==2.12.0-rc1 matplotlib pandas sklearn nltk gensim
+    dnf -y install cuda-toolkit cuda-toolkit-11-8 tensorrt && \
+    pip3 install --upgrade pip numpy wheel packaging requests opt_einsum keras_preprocessing && \
+    dnf -y copr enable vbatts/bazel && dnf -y install bazel5 && \
+    alternatives --set python /usr/bin/python2 && \
+    alternatives --set java $(readlink -f /usr/lib/jvm/java-11/bin/java) && \
+    alternatives --set javac $(readlink -f /usr/lib/jvm/java-11/bin/javac) && \
+    wget https://github.com/tensorflow/tensorflow/archive/refs/tags/v2.11.0.zip && unzip v2.11.0.zip && rm v2.11.0.zip && \
+    cd tensorflow-2.11.0/ && \
+    rm -f .bazelversion && \
+    cp /tmp/.tf_configure.bazelrc . && \
+    bash -i -c "bazel build //tensorflow/tools/pip_package:build_pip_package" && \
+    alternatives --set python /usr/bin/python3 && \
+    ./bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg && \
+    cd / && rm -rf /tensorflow-2.11.0 && rm -rf /root/.cache && \
+    pip3 install /tmp/tensorflow_pkg/tensorflow-2.11.0-cp38-cp38-linux_x86_64.whl && \
+    rm -rf /tmp/tensorflow_pkg && \
+    pip3 install  matplotlib pandas scikit-learn nltk gensim

--- a/grading/python3-deeplearning-gpu/Dockerfile
+++ b/grading/python3-deeplearning-gpu/Dockerfile
@@ -1,0 +1,17 @@
+# DOCKER-VERSION 1.1.0
+
+#inherit from the base container, which has all the needed script to launch tasks
+ARG   VERSION=latest
+FROM  ingi/inginious-c-base:${VERSION}
+LABEL org.inginious.grading.name="python3-deeplearning-gpu"
+LABEL org.inginious.grading.need_gpu=1
+
+# Expose GPUs with compute and utility capabilities
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+# Install CUDA packages and compatible tensorflow version
+RUN dnf -y install dnf-plugins-core gcc-c++ python38-pip python38-devel && \
+    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
+    dnf -y install cuda-toolkit-11-8 cuda-toolkit-12-0 tensorrt && \ 
+    pip3.8 install tensorflow==2.12.0-rc1 matplotlib pandas sklearn nltk gensim


### PR DESCRIPTION
This provides an GPU-enabled version of the deeplearning container with native arch support (to enable the available instruction sets). 

It is more or less a POC environment for  the nvidia runtime added in PR UCL-INGI/INGInious#915, and therefore requires the first one to be merged before moving on.

Here the cuda toolkit is installed in two versions : one for the tensorflow build, and the other to match the install host driver version. That's the way it works : https://docs.nvidia.com/deploy/cuda-compatibility/#cuda-intro. The user-mode driver should match the kernel driver. The runtime should be compatible with the driver version.